### PR TITLE
OA Team List TBA Option Addition

### DIFF
--- a/src/data/teams2024.json
+++ b/src/data/teams2024.json
@@ -36,6 +36,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/111",
+        "name": "TBA"
+      },
+      {
         "url": "https://cad.onshape.com/documents/3cfac28b1069c1daf6853747/w/4d63e656fbb8201161b14795/e/1373e5321b05597e914143b2",
         "name": "CAD"
       }
@@ -51,6 +55,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/112",
+        "name": "TBA"
+      },
+      {
         "url": "https://cad.onshape.com/documents/1d707fc04df5e84b269d72e4/w/a90ad6fcdf4f4f48bbd8315d/e/7a1a64b8cb079f2ea3f345a6",
         "name": "CAD"
       }
@@ -64,6 +72,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/team-177-bobcat-robotics-2024-build-blog/447633",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/177",
+        "name": "TBA"
       }
     ]
   },
@@ -75,6 +87,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-team-340-greater-rochester-robotics-2024-build-thread-open-alliance/443107/3",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/340",
+        "name": "TBA"
       },
       {
         "url": "https://github.com/Greater-Rochester-Robotics/GRRBase",
@@ -98,6 +114,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/342-the-burning-magnetos-2024-open-alliance-thread/444550",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/342",
+        "name": "TBA"
       }
     ]
   },
@@ -109,6 +129,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-555-montclair-robotics-2024-build-thread/442706",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/555",
+        "name": "TBA"
       }
     ]
   },
@@ -120,6 +144,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-team-587-the-hedgehogs-2024-build-season-thread/442427",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/587",
+        "name": "TBA"
       },
       {
         "url": "https://cad.onshape.com/documents/0ff54580033714c409ff00a0/w/1bc3f696902740f8553c42f3/e/38194658055e71f7ec65f8a8",
@@ -141,6 +169,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/599",
+        "name": "TBA"
+      },
+      {
         "url": "https://robodox.smugmug.com/",
         "name": "Photos"
       },
@@ -160,6 +192,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/611",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/LangleyRobotics/24-Bot-Test",
         "name": "Code"
       }
@@ -173,6 +209,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/847-phred-2024-open-alliance-build-thread/447070?u=rufus_t_doofus",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/847",
+        "name": "TBA"
       },
       {
         "url": "https://cad.onshape.com/documents/7ff5fae5e4325b97c718284a/w/e7399e20e1a18d4c8e087ab9/e/c23f8b58ca273f08c6fd3463?renderMode=0&uiState=6590d7db5531ce75ff43482a",
@@ -194,6 +234,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/900",
+        "name": "TBA"
+      },
+      {
         "url": "http://github.com/frc900",
         "name": "Code"
       },
@@ -211,6 +255,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/nrg-948-2023-2024-open-alliance-thread/443508",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/947",
+        "name": "TBA"
       }
     ]
   },
@@ -222,6 +270,10 @@
       {
         "url": "https://link.broncobotics.org/2024-build-thread",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/991",
+        "name": "TBA"
       },
       {
         "url": "https://link.broncobotics.org/2024-CAD",
@@ -247,6 +299,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/997",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/Team997Coders/2024Crescendo.git",
         "name": "Code"
       },
@@ -266,6 +322,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/1038",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/LakotaRobotics1038",
         "name": "Code"
       }
@@ -281,6 +341,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/1072",
+        "name": "TBA"
+      },
+      {
         "url": "https://www.youtube.com/@Harker1072",
         "name": "Videos"
       }
@@ -294,6 +358,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-1102-maiken-magic-2024-build-thread-open-alliance/443128",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/1102",
+        "name": "TBA"
       },
       {
         "url": "https://github.com/MAikenMagic1102",
@@ -319,6 +387,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/1155",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/SciBorgs",
         "name": "Code"
       }
@@ -332,6 +404,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-1294-pack-of-parts-2024-build-thread-open-alliance-2024/441658",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/1294",
+        "name": "TBA"
       }
     ]
   },
@@ -343,6 +419,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/1339-open-alliance-open-content-for-the-2024-game/440346",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/1139",
+        "name": "TBA"
       },
       {
         "url": "https://cad.onshape.com/documents?nodeId=93df25d0ae1e2c3c3f00cf3d&resourceType=folder",
@@ -360,6 +440,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/1418",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/frc1418",
         "name": "Code"
       }
@@ -373,6 +457,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-1466-webb-robotics-2024-build-thread/446029",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/1466",
+        "name": "TBA"
       },
       {
         "url": "https://cad.onshape.com/documents/cb5a0430dc81e6ef948e969a/w/144b474944160f03812fef56/e/59191ae8df8bdefa2e666561?renderMode=0&uiState=6586fbc843790f77f7a11143",
@@ -398,6 +486,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/1540",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/flamingchickens1540",
         "name": "Code"
       }
@@ -411,6 +503,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-1675-ups-2024-build-thread-open-alliance/444686",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/1675",
+        "name": "TBA"
       },
       {
         "url": "https://cad.onshape.com/documents/6ff9bc0674fd1ef12e3a75d3/w/612009e1bf5762a41e85f3b1/e/41b00e4105c7ed1aca36abad",
@@ -432,6 +528,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/1699",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/FIRST-Team-1699",
         "name": "Code"
       },
@@ -449,6 +549,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-team-1710-2024-build-thread-open-alliance/442068?u=coreybrown",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/1710",
+        "name": "TBA"
       },
       {
         "url": "https://github.com/FRC-Team-1710/2024-Robot",
@@ -470,6 +574,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/1757",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/1757WestwoodRobotics/2024-Crescendo",
         "name": "Code"
       }
@@ -483,6 +591,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-1787-the-flying-circuits-2024-open-alliance-thread/442930",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/1787",
+        "name": "TBA"
       },
       {
         "url": "https://cad.onshape.com/documents/e6d7b50150275636203e85d2/w/2c58e6c3c9ceca078b4758ff/e/ebbab5a0b88145d6af183edb?renderMode=0&uiState=6527e587e21671140e3718e5",
@@ -510,6 +622,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-1792-round-table-robotics-2024-build-thread-open-alliance/444623",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/1792",
+        "name": "TBA"
       }
     ]
   },
@@ -521,6 +637,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-1806-s-w-a-t-2024-build-thread/447060",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/1806",
+        "name": "TBA"
       },
       {
         "url": "https://cad.onshape.com/documents/241f2253507606c76021332d/w/af9b88b7a8fe9387e4a7ba96/e/279410e9fe0c1ef537b2a937",
@@ -542,6 +662,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/1899",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/SaintsRobotics",
         "name": "Code"
       },
@@ -561,6 +685,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/2022",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/titan2022/FRC-2024-JAVA",
         "name": "Code"
       }
@@ -574,6 +702,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-2059-the-hitchhikers-2024-build-thread/447104",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/2059",
+        "name": "TBA"
       }
     ]
   },
@@ -585,6 +717,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/2220-blue-twilight-2024-build-thread/443797",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/2220",
+        "name": "TBA"
       },
       {
         "url": "https://cad.onshape.com/documents/dc63bcf5db5751789191f400/w/f81d599ddc067aae3367f808/e/27e38c47f7f1f73c02acc042?renderMode=0&uiState=659d5432dbdc413dec7c3f58",
@@ -606,6 +742,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/2342",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/FRCTeamPhoenix",
         "name": "Code"
       }
@@ -619,6 +759,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/2357-system-meltdown-2024-open-alliance-build-thread/447112",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/2357",
+        "name": "TBA"
       },
       {
         "url": "https://a360.co/3vsZjHK",
@@ -640,6 +784,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/2412",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/robototes/Crescendo2024/",
         "name": "Code"
       }
@@ -653,6 +801,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/2521-sert-2024-open-alliance-build-thread/447639",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/2521",
+        "name": "TBA"
       }
     ]
   },
@@ -664,6 +816,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/2582-pantherbots-build-blog-open-alliance-2024/443543",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/2582",
+        "name": "TBA"
       },
       {
         "url": "https://cad.onshape.com/documents/a298aa03e45ed9212c189793/w/e95a5f4fa14e2a9c0c823956/e/c2d661b7f5fa8bb351c8860c?renderMode=0&uiState=6542f24a115608246bffaefa",
@@ -683,6 +839,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/discobots-2587-build-blog-2024/446938",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/2587",
+        "name": "TBA"
       },
       {
         "url": "https://github.com/discobots2587",
@@ -708,6 +868,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/2656",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/quasics/quasics-frc-sw-2015/wiki",
         "name": "Code"
       }
@@ -721,6 +885,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-2846-firebears-2024-build-thread-open-alliance/446950",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/2846",
+        "name": "TBA"
       },
       {
         "url": "https://cad.onshape.com/documents/a41f7880f6b71b225c7c47f0/w/a2caec1006c2ddcc1aa44a83/e/901fc9c696f9fdd5e00a77e5",
@@ -742,6 +910,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/2869",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/orgs/FRC2869/repositories",
         "name": "Code"
       }
@@ -755,6 +927,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/ligerbots-2877-open-alliance-build-thread-2024/445564",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/2877",
+        "name": "TBA"
       },
       {
         "url": "https://www.flickr.com/photos/ligerbots/",
@@ -776,6 +952,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/2996",
+        "name": "TBA"
+      },
+      {
         "url": "https://cad.onshape.com/documents/07d4cc55e2898257b034f0a6/w/f765693f27059b00730e8b6f/e/1dd9c1d97b9b1f8ecb5f3cda?renderMode=0&uiState=6587323d28d9942be74462a2",
         "name": "CAD"
       },
@@ -793,6 +973,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-3061-huskie-robotics-2024-season-build-thread/447553",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/3061",
+        "name": "TBA"
       },
       {
         "url": "https://cad.onshape.com/documents/8a473118aa5dbbe6ac4c94e7/w/149c4500630ea6c7fc71b6e0/e/93d32ec0c12d832acf9f253d?renderMode=0&uiState=65977dbba48c097d04000315",
@@ -816,6 +1000,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-3082-chicken-bot-pie-2024-build-thread-open-alliance/445300?",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/3082",
+        "name": "TBA"
       }
     ]
   },
@@ -827,6 +1015,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/tronic-titans-3161-build-thread-open-alliance-2024/447265",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/3161",
+        "name": "TBA"
       },
       {
         "url": "https://www.flickr.com/photos/htrobotics/",
@@ -848,6 +1040,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/3175",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/frc3175",
         "name": "Code"
       }
@@ -861,6 +1057,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-3181-pittsford-robotics-2024-build-thread/443678",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/3181",
+        "name": "TBA"
       },
       {
         "url": "https://github.com/pittsfordrobotics",
@@ -882,6 +1082,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/3205",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/CCHS-FIRST-Robotics",
         "name": "Code"
       },
@@ -901,6 +1105,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/3467",
+        "name": "TBA"
+      },
+      {
         "url": "https://cad.onshape.com/documents/2fc7c67cf0caa47d6fd88b44/w/50f8171b9e5f18a6a9f1f1d8/e/bc85563405848dc625f6a416?renderMode=0&uiState=659428364c84e33f26e6df12",
         "name": "CAD"
       },
@@ -918,6 +1126,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-3481-2024-build-thread-open-alliance/441981",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/3481",
+        "name": "TBA"
       },
       {
         "url": "https://github.com/BroncBotz3481/FRC2024",
@@ -941,6 +1153,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/3512-spartatroniks-build-blog-open-alliance-2024/447505/2",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/3512",
+        "name": "TBA"
       },
       {
         "url": "https://cad.onshape.com/documents/5793c7749bf6f5dcea549944/w/63aff5377fec1a1fd1ccf4be/e/d3c670d67e51b8412f8dc9cd?renderMode=0&uiState=659787366dc9ca65fa51bfd4",
@@ -970,6 +1186,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/3544",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/Spartiates-3544",
         "name": "Code"
       }
@@ -985,6 +1205,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/3588",
+        "name": "TBA"
+      },
+      {
         "url": "https://www.youtube.com/channel/UCzsfDJcqKRseT9NnyJkYyqA",
         "name": "Videos"
       }
@@ -998,6 +1222,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-team-3636-generals-robotics-2024-build-thread/442713",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/3636",
+        "name": "TBA"
       }
     ]
   },
@@ -1009,6 +1237,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-team-3735-vortx-2024-build-thread-open-alliance/442383?u=lewislongbottom",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/3735",
+        "name": "TBA"
       },
       {
         "url": "https://cad.onshape.com/documents/8d89565820455e63a18491d4/w/610ee48d22be46a4902dabb2/e/934747479de237643943d414?renderMode=0&uiState=6528943578df916591d8a18d",
@@ -1038,6 +1270,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/3847",
+        "name": "TBA"
+      },
+      {
         "url": "https://2024cad.spectrum3847.org",
         "name": "CAD"
       },
@@ -1065,6 +1301,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/3926",
+        "name": "TBA"
+      },
+      {
         "url": "https://cad.onshape.com/documents/131b2c5540b699169878a6a9/w/ecaa21e81d19db0b64cdd280/e/09f035a63548efb0cad7d354?renderMode=0&uiState=658649ed6f79aa00b38bd054",
         "name": "CAD"
       },
@@ -1088,6 +1328,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/4118",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/FRC-Riptide-4118",
         "name": "Code"
       },
@@ -1107,6 +1351,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/4121",
+        "name": "TBA"
+      },
+      {
         "url": "https://www.youtube.com/channel/UC-gmjmRqpLVbWAXwTU_2t7A",
         "name": "Videos"
       }
@@ -1120,6 +1368,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-4272-maverick-robotics-2024-build-thread/446149",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/4272",
+        "name": "TBA"
       },
       {
         "url": "https://cad.onshape.com/documents/57c035edd4bbacab38fe9519/w/6008ad65869098ff59f8d4f7/e/fcccb838cf64afbc93fe9012",
@@ -1145,6 +1397,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/4276",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/team4276",
         "name": "Code"
       },
@@ -1164,6 +1420,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/4322",
+        "name": "TBA"
+      },
+      {
         "url": "https://cad.onshape.com/documents/be8222853694a7499c37aef8/w/017b66ac52cf8deddc8d1719/e/ec8c4b4ae5dc7f6b8d13f99f",
         "name": "CAD"
       },
@@ -1181,6 +1441,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-4481-team-rembrandts-2024-build-thread-open-alliance/441907",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/4481",
+        "name": "TBA"
       },
       {
         "url": "https://grabcad.com/team.rembrandts.4481-1",
@@ -1206,6 +1470,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/4504",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/BC-Robotics-4504/2024-Season",
         "name": "Code"
       }
@@ -1219,6 +1487,14 @@
       {
         "url": "https://www.chiefdelphi.com/t/team-scream-open-alliance-team-4522-and-4766-build-thread-2024/442547",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/4522",
+        "name": "TBA"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/4522",
+        "name": "TBA"
       }
     ]
   },
@@ -1230,6 +1506,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/4561-the-terrorbytes-2024-build-thread-open-alliance/441963?u=richstar123",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/4561",
+        "name": "TBA"
       },
       {
         "url": "https://github.com/FRC4561TerrorBytes",
@@ -1249,6 +1529,10 @@
       {
         "url": "https://www.google.com/url?q=https%3A%2F%2Fwww.chiefdelphi.com%2Ft%2F4573-rambotics-2024-build-thread-open-alliance%2F441905%2F2&sa=D&sntz=1&usg=AOvVaw2IHCCQ-8Olzmu0wxYRj5Dy",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/4573",
+        "name": "TBA"
       }
     ]
   },
@@ -1260,6 +1544,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-4639-the-robospartans-2024-build-thread-open-alliance/444907?u=4639member",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/4639",
+        "name": "TBA"
       }
     ]
   },
@@ -1271,6 +1559,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/cant-control-4788-build-blog-2024/442349?u=hazzer",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/4788",
+        "name": "TBA"
       },
       {
         "url": "https://github.com/CurtinFRC/2024-Crescendo",
@@ -1292,6 +1584,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/4795",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/Team-4795",
         "name": "Code"
       },
@@ -1309,6 +1605,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-4828-roboeagles-2024-build-thread-open-alliance/441753",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/4828",
+        "name": "TBA"
       },
       {
         "url": "https://cad.onshape.com/documents/5f509c0eb99a21f4f3b5c307/w/5a24af5198ae222a44753e9a/e/8b59b01449f53b70d8bf81b6?renderMode=0&uiState=658c9a51d4f6f843871ad36f",
@@ -1330,6 +1630,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/4926",
+        "name": "TBA"
+      },
+      {
         "url": "https://a360.co/3RtfQmA",
         "name": "CAD"
       }
@@ -1343,6 +1647,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/5013-trobots-2024-build-thread-open-alliance/442526",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/5013",
+        "name": "TBA"
       },
       {
         "url": "https://cad.onshape.com/documents/873dc575387fdfc347483ad6/w/080207b04ab992e3bfc17df4/e/c37cce0029b24eae146f8504",
@@ -1366,6 +1674,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/5119-team-steam-2024-open-alliance-build-thread/442086?u=singtothehippos",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/5119",
+        "name": "TBA"
       }
     ]
   },
@@ -1377,6 +1689,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/celt-x-5406-2024-build-thread-open-alliance/447624",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/5406",
+        "name": "TBA"
       },
       {
         "url": "https://www.youtube.com/@CeltXRobotics",
@@ -1394,6 +1710,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/5417",
+        "name": "TBA"
+      },
+      {
         "url": "https://www.youtube.com/@ATeamRobotics",
         "name": "Videos"
       }
@@ -1407,6 +1727,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-5431-titan-robotics-open-alliance-thread-2024/448265",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/5431",
+        "name": "TBA"
       },
       {
         "url": "https://a360.co/47pR2Sy",
@@ -1426,6 +1750,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/ipswich-tigers-5459-2024-build-thread-open-alliance/442730",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/5459",
+        "name": "TBA"
       }
     ]
   },
@@ -1437,6 +1765,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/5553-robolyon-2024-build-thread/446875",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/5553",
+        "name": "TBA"
       }
     ]
   },
@@ -1448,6 +1780,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/the-omegabytes-2024-open-alliance-thread/442911",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/5727",
+        "name": "TBA"
       },
       {
         "url": "https://cad.onshape.com/documents/0eef4eb2229c5cade86dfe1b/w/6c15777d7e3e87e8ca3036c0/e/79f9f2eab0b3ded1b6e65cbc",
@@ -1467,6 +1803,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/5788-eagle-special-operations-build-blog-open-alliance-2024/447343",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/5788",
+        "name": "TBA"
       }
     ]
   },
@@ -1478,6 +1818,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-5951-makers-assemble-2024-build-thread-open-alliance-2024/440234",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/5951",
+        "name": "TBA"
       },
       {
         "url": "https://github.com/MA5951",
@@ -1499,6 +1843,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/5987",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/Galaxia5987",
         "name": "Code"
       }
@@ -1518,6 +1866,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-6328-mechanical-advantage-2024-build-thread/442736?u=davepowers",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/6328",
+        "name": "TBA"
       },
       {
         "url": "https://cad.onshape.com/documents/7c35c1fa63a6f3101a460578/w/1ebd54459aebecf8e5373569/e/6a1c80d9ec77d86a62e8c1ae",
@@ -1543,6 +1895,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/6369",
+        "name": "TBA"
+      },
+      {
         "url": "https://cad.onshape.com/documents/7fbe1ca86c57b27d97c3045c/w/f9ebbb5ce91c19b1cefe3c5d/e/1c39319a3d03d448814a4101",
         "name": "CAD"
       },
@@ -1564,6 +1920,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/6421-warriorbots-2024-build-thread-open-alliance/446521",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/6421",
+        "name": "TBA"
       },
       {
         "url": "https://cad.onshape.com/documents/61b3ef49301a92d27eb99a8c/w/05ed559182806cbd0433d6ee/e/2193f1e464c2428ff06fbcec",
@@ -1589,6 +1949,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/6643",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/Team6643/2024-robot",
         "name": "Code"
       }
@@ -1602,6 +1966,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-6647-voltec-robotics-2024-build-thread-open-alliance/447300",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/6647",
+        "name": "TBA"
       }
     ]
   },
@@ -1613,6 +1981,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/x-sharc-6838-build-blog-2024/447670",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/6838",
+        "name": "TBA"
       },
       {
         "url": "https://github.com/X-SHARC",
@@ -1634,6 +2006,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/6908",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/frc6908",
         "name": "Code"
       },
@@ -1651,6 +2027,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-team-6925-woodward-academy-robotics-2024-build-thread-open-alliance/443629",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/6925",
+        "name": "TBA"
       }
     ]
   },
@@ -1662,6 +2042,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-7125-tigerbotics-2024-build-thread/448639?u=tigerbotics",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/7125",
+        "name": "TBA"
       },
       {
         "url": "https://github.com/Tigerbotics7125/FRC2024/tree/main",
@@ -1679,6 +2063,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/7312",
+        "name": "TBA"
+      },
+      {
         "url": "https://cad.onshape.com/documents/ab755897c017dd95da77ac0a/w/7f7e30782dc7975a054f80be/e/5b92345d2c87e9cada9f5118?renderMode=0&uiState=65aab5c110447463cc1f3c27",
         "name": "CAD"
       }
@@ -1694,6 +2082,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/7407",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/Choate-Robotics",
         "name": "Code"
       }
@@ -1707,6 +2099,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/overture-7421-build-blog-2024-open-alliance/446286",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/7421",
+        "name": "TBA"
       },
       {
         "url": "https://cad.onshape.com/documents/7713014d9581fd5ca14c0274/w/367b9afcf469d7b155e49540/e/0bb998828847636219fa081d?renderMode=0&uiState=65684f66b830fc25523287f6",
@@ -1728,6 +2124,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/7461",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/SushiSquad7461/oshi-yoshi-2024",
         "name": "Code"
       }
@@ -1741,6 +2141,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/7525-the-pioneers-2024-build-thread-open-alliance/442615",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/7525",
+        "name": "TBA"
       }
     ]
   },
@@ -1752,6 +2156,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-8088-bionic-panthers-2024-build-thread-open-alliance/446779",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/8088",
+        "name": "TBA"
       },
       {
         "url": "https://github.com/liberty-hill-high-school-robotics",
@@ -1771,6 +2179,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/vector-8177-build-thread-open-alliance-2024/446842?u=connor-8177",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/8177",
+        "name": "TBA"
       },
       {
         "url": "https://cad.onshape.com/documents/c59eba62f3539e110f41846b/w/d12d9680394924b761171bed/e/d4229c0767dff5e38d4ee7f5?renderMode=0&uiState=658609c450efe556720da3e8",
@@ -1794,6 +2206,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/8230-koibots-2024-build-thread-open-alliance/446977",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/8230",
+        "name": "TBA"
       }
     ]
   },
@@ -1805,6 +2221,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/cartesian-robotics-8561-build-blog-2024/449021?u=ege_dgny",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/8561",
+        "name": "TBA"
       }
     ]
   },
@@ -1816,6 +2236,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/8574-audeamus-2024-open-alliance-build-thread/450541",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/8574",
+        "name": "TBA"
       },
       {
         "url": "https://github.com/roboticsmgci",
@@ -1837,6 +2261,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/8626",
+        "name": "TBA"
+      },
+      {
         "url": "https://cad.onshape.com/documents/04d879d46f159b088a1fc4f7",
         "name": "CAD"
       },
@@ -1856,6 +2284,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/8725",
+        "name": "TBA"
+      },
+      {
         "url": "https://www.youtube.com/channel/UCDnqDUfKrUdcqkpwK34f61w",
         "name": "Videos"
       }
@@ -1869,6 +2301,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/8738-slice-2024-open-alliance-build-thread/443213?u=flightpath24",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/8738",
+        "name": "TBA"
       }
     ]
   },
@@ -1880,6 +2316,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/galatasaray-robotics-9020-2023-2024-open-alliance-build-thread/441576",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/9020",
+        "name": "TBA"
       },
       {
         "url": "https://github.com/gsrobotics9020",
@@ -1903,6 +2343,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/9033-ocebots-2024-build-thread-open-alliance/447912?u=joot49",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/9033",
+        "name": "TBA"
       }
     ]
   },
@@ -1914,6 +2358,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-9047-techmaker-robotics-2024-build-thread-open-alliance/447199",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/9047",
+        "name": "TBA"
       },
       {
         "url": "https://cad.onshape.com/documents/4d9f2de7c0eff949230360fc/w/8ebbb82313338ddcf726cff6/e/2fbd2c0355381ef0f91ff9a1",
@@ -1937,6 +2385,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-9312-nerd-spark-2024-build-thread/449112",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/9312",
+        "name": "TBA"
       },
       {
         "url": "https://cad.onshape.com/documents/f8c08b4811d03faba91e8ac1/w/f977a100d492db5a37604f46/e/1df05d11a71f59dcdadbb542?renderMode=0&uiState=659e100f8c1904531f33e84e",
@@ -1966,6 +2418,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/9496",
+        "name": "TBA"
+      },
+      {
         "url": "https://github.com/LynkRobotics",
         "name": "Code"
       },
@@ -1983,6 +2439,10 @@
       {
         "url": "https://www.chiefdelphi.com/t/frc-9586-anglebotics-2024-build-thread",
         "name": "Build Thread"
+      },
+      {
+        "url": "https://www.thebluealliance.com/team/9586",
+        "name": "TBA"
       },
       {
         "url": "https://anglebotics.org/github",

--- a/src/data/teams2024.json
+++ b/src/data/teams2024.json
@@ -9,6 +9,10 @@
         "name": "Build Thread"
       },
       {
+        "url": "https://www.thebluealliance.com/team/95",
+        "name": "TBA"
+      },
+      {
         "url": "https://cad.onshape.com/documents/f46ce37811abb74c2758f7c0/w/83a535398edd5745c434f8fc/e/6a7da0047664270d513c2f2a",
         "name": "CAD"
       },


### PR DESCRIPTION
# Added all the OA Teams TBA Links <br>

Reasoning: When I scroll through the OA website and see a team, I want a button to view that team on TBA to see their matches and how well the team did. This would save an extra step of opening a new tab, going to TBA, and looking up the team. 

--
Stay Cool,
Jimmy McCosker
Lynk 9496 Programmer / Omegabytes 5727 Alumni
CD: [Jimmyy](https://www.chiefdelphi.com/u/jimmyy)
GitHub: [witherslayer67](https://github.com/witherslayer67) 
"Words have power, but only when people will listen. When they won't, actions speak loud enough for anyone." -Ryosuke Takahashi